### PR TITLE
chore(formula): add manpage generation and installation for af

### DIFF
--- a/Formula/af.rb
+++ b/Formula/af.rb
@@ -20,6 +20,9 @@ class Af < Formula
     system "cargo", "install", *std_cargo_args
 
     generate_completions_from_executable(bin / "af", "completions")
+
+    system "cargo", "genman"
+    man1.install Dir["docs/man/man1/*.1"]
   end
 
   test do


### PR DESCRIPTION
- runs `cargo genman` during install
- installs generated manpages to the appropriate man1 directory