### PR TITLE
chore(renovate): disable dashboard approval for automerged non-major updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -18,7 +18,8 @@
         "minor",
         "patch"
       ],
-      "automerge": true
+      "automerge": true,
+      "dependencyDashboardApproval": false
     }
   ]
 }


### PR DESCRIPTION
- keeps automerge enabled for patch and minor versions
- avoids requiring manual approval in the dependency dashboard