### PR TITLE
chore(renovate): update config to remove default commit type and customize PR body

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,13 +4,13 @@
   "extends": [
     "config:best-practices",
     ":gitSignOff",
-    ":label(dependencies)",
-    ":semanticCommitTypeAll(chore)"
+    ":label(dependencies)"
   ],
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true
   },
+  "prBodyTemplate": "{{{header}}}{{{table}}}{{{warnings}}}{{{notes}}}{{{changelogs}}}{{{controls}}}",
   "packageRules": [
     {
       "description": "Automerge non-major updates",


### PR DESCRIPTION
- removes :semanticCommitTypeAll(chore) to allow custom commit titles
- adds prBodyTemplate to structure Renovate PRs consistently